### PR TITLE
Refactor/remove test data from app

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import { PlanetBio, AllData } from '../../interface';
 import { discoverPlanets } from '../../apiCalls.js';
-import planetData from '../../data/planetData.js';
+// import planetData from '../../data/planetData.js';
 import Planetarium from '../Planetarium/Planetarium';
 import PlanetInfo from '../PlanetInfo/PlanetInfo';
 import Header from '../Header/Header';
@@ -14,7 +14,7 @@ class App extends React.Component<{}, AllData> {
     super(props);
     this.state = {
       allPlanets: [],
-      sortKey: 'distance_from_sun'
+      sortKey: ''
     };
   }
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -13,7 +13,7 @@ class App extends React.Component<{}, AllData> {
   constructor(props: any) {
     super(props);
     this.state = {
-      allPlanets: planetData,
+      allPlanets: [],
       sortKey: 'distance_from_sun'
     };
   }
@@ -37,11 +37,11 @@ class App extends React.Component<{}, AllData> {
     return (
       <div className="App">
         <Header />
-
         <Route exact path="/" render={() => {
           return (
             <main>
               <SortBox updateSort={this.updateSort} />
+              {!this.state.allPlanets.length && <h2>Loading...</h2>}
               <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
             </main>
           )

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -11,12 +11,10 @@ interface PlanetProps {
 const Planet: React.FC<PlanetProps> = ({ id, name, planetFact }): JSX.Element => {
 
   return (
-    <Link to={`/${name.toLowerCase()}`}>
-      <article className='planet-card' id={id.toString()}>
-        <img className='planet-icon' alt='earth' src={`../planets/${name}.png`} />
-        <h2 className='planet-card-name'>{name}</h2>
-        <p className='planet-card-fact'>{planetFact}</p>
-      </article>
+    <Link to={`/${name.toLowerCase()}`} className='planet-card' id={id.toString()}>
+      <img className='planet-icon' alt='earth' src={`../planets/${name}.png`} />
+      <h2 className='planet-card-name'>{name}</h2>
+      <p className='planet-card-fact'>{planetFact}</p>
     </Link>
   )
 }

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -24,7 +24,10 @@ const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element =>
   }
 
   const planetCards = allPlanets.map(planet => {
-    const factData: string | number = planet[sortKey as keyof PlanetBio]
+    let factData: string | number = planet[sortKey as keyof PlanetBio];
+    if (!factData) {
+      factData = '';
+    }
     return (
       <Planet
         name={planet.name}

--- a/src/components/SortBox/SortBox.tsx
+++ b/src/components/SortBox/SortBox.tsx
@@ -10,7 +10,7 @@ const SortBox: React.FC<Props> = ({ updateSort }) => {
     <section className='sort-box'>
       <h2>Sort planets by:</h2>
       <div className='sort-options'>
-        <input type="radio" onClick={updateSort} id="distance" name="sortCriteria" value="distance_from_sun" defaultChecked></input>
+        <input type="radio" onClick={updateSort} id="distance" name="sortCriteria" value="distance_from_sun"></input>
         <label htmlFor="distance"><img className='sort-icon' alt='astronaut icon' src='../space/sun.png'></img>Distance from sun</label>
         <input type="radio" onClick={updateSort} id="mass" name="sortCriteria" value="mass"></input>
         <label htmlFor="mass"><img className='sort-icon' alt='astronaut icon' src='../space/asteroid.png'></img>Mass</label>


### PR DESCRIPTION
# PR PlanetParty
**Connor A-L, Alex T & Katie B**

### What does this do?

- [X] Fix
- [ ] Feature
- [X] Refactor
- [X] Style
- [ ] Testing

### Are there any known bugs?

- [X] No
- [ ] Yes (if so please disclose in Notes for Reviewer & Next Iterations)

### Summary of the changes

1. Remove the `article` element from the `Planet` component so styling matches the original comp.
2. Remove test data from `App` component so on page load, the `allPlanet` state is an empty array, then add a loading message that should be styled later so a loading message appears under the sort box on page load when page is rendering and getting data from API.
3. Remove the default selection of `sort by distance to the sun`. Then add a conditional statement to the `Planetarium` component, specifically the `planetCards` variable so that no planet fact renders to the page on initial page load.


### What ticket(s) do the changes resolve?
#38 
Please Link Issues to this PR as necessary.

### Notes for the Reviewer
See above for a detailed overview of changes.
Loading message can be styled later.


### How to Test Changes?
Open the app locally, should see no default sort selected. Should view a loading message under the sort box when page is getting API data.

### Next Iterations
Style loading message. Maybe refactor conditional rendering loading to check for errors first.
