### PR TITLE
Styling/polish

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -27,11 +27,11 @@ export const discoverPlanets = () => {
         id: info.id,
         name: info.englishName,
         mass: parseMass(info.mass.massValue, info.mass.massExponent),
-        diameter: (info.meanRadius * 2),
-        gravity: info.gravity,
-        length_of_day: Math.abs(info.sideralRotation),
+        diameter: Math.round(info.meanRadius * 2),
+        gravity: info.gravity.toFixed(2),
+        length_of_day: Math.abs(info.sideralRotation).toFixed(1),
         distance_from_sun: info.semimajorAxis,
-        length_of_year: info.sideralOrbit,
+        length_of_year: (info.sideralOrbit.toFixed(2) * 100)/100,
         number_of_moons: info.moons?.length || 0
       }
     }))

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -26,7 +26,7 @@ export const discoverPlanets = () => {
       return {
         id: info.id,
         name: info.englishName,
-        mass: info.mass.massValue,
+        mass: parseMass(info.mass.massValue, info.mass.massExponent),
         diameter: (info.meanRadius * 2),
         gravity: info.gravity,
         length_of_day: Math.abs(info.sideralRotation),
@@ -35,6 +35,11 @@ export const discoverPlanets = () => {
         number_of_moons: info.moons?.length || 0
       }
     }))
+}
+
+const parseMass = (value, exponent) => {
+  const delta = exponent - 18; //to find exponent beyone 10^18 (quintillion)
+  return (value * Math.pow(10, delta));
 }
 
 // id, englishName, moons, mass, gravity, massValue, massExponent, moon, meanRadius, sideralOrbit, sideralRotation, semimajorAxis

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import { PlanetBio, AllData } from '../../interface';
 import { discoverPlanets } from '../../apiCalls.js';
-import planetData from '../../data/planetData.js';
+// import planetData from '../../data/planetData.js';
 import Planetarium from '../Planetarium/Planetarium';
 import PlanetInfo from '../PlanetInfo/PlanetInfo';
 import Header from '../Header/Header';
@@ -14,7 +14,7 @@ class App extends React.Component<{}, AllData> {
     super(props);
     this.state = {
       allPlanets: [],
-      sortKey: 'distance_from_sun'
+      sortKey: ''
     };
   }
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -13,7 +13,7 @@ class App extends React.Component<{}, AllData> {
   constructor(props: any) {
     super(props);
     this.state = {
-      allPlanets: planetData,
+      allPlanets: [],
       sortKey: 'distance_from_sun'
     };
   }
@@ -37,11 +37,11 @@ class App extends React.Component<{}, AllData> {
     return (
       <div className="App">
         <Header />
-
         <Route exact path="/" render={() => {
           return (
             <main>
               <SortBox updateSort={this.updateSort} />
+              {!this.state.allPlanets.length && <h2>Loading...</h2>}
               <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
             </main>
           )

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -11,12 +11,10 @@ interface PlanetProps {
 const Planet: React.FC<PlanetProps> = ({ id, name, planetFact }): JSX.Element => {
 
   return (
-    <Link to={`/${name.toLowerCase()}`}>
-      <article className='planet-card' id={id.toString()}>
-        <img className='planet-icon' alt='earth' src={`../planets/${name}.png`} />
-        <h2 className='planet-card-name'>{name}</h2>
-        <p className='planet-card-fact'>{planetFact}</p>
-      </article>
+    <Link to={`/${name.toLowerCase()}`} className='planet-card' id={id.toString()}>
+      <img className='planet-icon' alt='earth' src={`../planets/${name}.png`} />
+      <h2 className='planet-card-name'>{name}</h2>
+      <p className='planet-card-fact'>{planetFact}</p>
     </Link>
   )
 }

--- a/src/components/Planet/planet.css
+++ b/src/components/Planet/planet.css
@@ -6,7 +6,8 @@
   display: flex;
   flex-direction: column;
   width: 20%;
-  margin: 10px 15px;
+  margin: 10px 15px 40px 15px;
+  text-decoration: none;
 }
 
 .planet-icon {
@@ -29,6 +30,16 @@
 .planet-icon:hover ~ .Saturn {
   color: #F5AE45;
 }
+
+.planet-card-name {
+  margin: 20px 10px 10px 10px;
+}
+
+.planet-card-fact {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
 
 @media only screen and (max-width: 850px) {
   .planet-card {

--- a/src/components/Planet/planet.css
+++ b/src/components/Planet/planet.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   width: 20%;
-  margin: 10px 15px 40px 15px;
+  margin: 10px 25px 40px 25px;
   text-decoration: none;
 }
 

--- a/src/components/PlanetInfo/PlanetInfo.tsx
+++ b/src/components/PlanetInfo/PlanetInfo.tsx
@@ -17,14 +17,14 @@ const PlanetInfo: React.FC<InfoProps> = ({ currentPlanet }): JSX.Element => {
       <h2 className='planet-info-title' >{name}</h2>
       <img className='planet-info-img' src={`../planet-pics/${name}-pic.jpg`} alt={name}></img>
       <article className='planet-info-box'>
-        <h3>{name} Fun Facts:</h3>
+        <h3 className='fun-fact-header'>{name} Fun Facts</h3>
         <ul className='planet-info-list'>
-          <li><b>Distance from the sun:</b> {distance_from_sun}</li>
-          <li><b>Mass:</b> {mass} </li>
-          <li><b>Diameter:</b> {diameter} </li>
-          <li><b>Gravity:</b> {gravity} </li>
-          <li><b>Length of day:</b> {length_of_day}</li>
-          <li><b>Length of year:</b> {length_of_year}</li>
+          <li><b>Distance from the sun:</b> {distance_from_sun} km</li>
+          <li><b>Mass:</b> {mass} kg</li>
+          <li><b>Diameter:</b> {diameter} km</li>
+          <li><b>Gravity:</b> {gravity} m/s²</li>
+          <li><b>Length of day:</b> {length_of_day} hours</li>
+          <li><b>Length of year:</b> {length_of_year} days</li>
           <li><b>Number of moons:</b> {number_of_moons}</li>
         </ul>
       </article>

--- a/src/components/PlanetInfo/planetInfo.css
+++ b/src/components/PlanetInfo/planetInfo.css
@@ -23,10 +23,19 @@
   border: 5px solid #D0D7DF;
   width: 70%;
   align-self: center;
-  margin-top: 20px;
+  margin-top: 30px;
+}
+
+.fun-fact-header {
+  margin: 10px 10px 25px 10px;
+  font-size: 2rem;
 }
 
 .planet-info-list {
   list-style: none;
   padding: 0;
+}
+
+.planet-info-list li {
+  margin: 10px;
 }

--- a/src/components/PlanetInfo/planetInfo.css
+++ b/src/components/PlanetInfo/planetInfo.css
@@ -15,7 +15,7 @@
 }
 
 .planet-info-img {
-  width: 200px;
+  width: 400px;
   align-self: center;
 }
 
@@ -38,4 +38,16 @@
 
 .planet-info-list li {
   margin: 10px;
+}
+
+@media only screen and (max-width: 850px) {
+  .planet-info-img {
+    width: 300px;
+  }
+}
+
+@media only screen and (max-width: 580px) {
+  .planet-info-img {
+    width: 200px;
+  }
 }

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -25,7 +25,7 @@ const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element =>
 
   const planetCards = allPlanets.map(planet => {
     let factData: string | number = planet[sortKey as keyof PlanetBio];
-    if (!factData) {
+    if (factData === undefined) {
       factData = '';
     }
     return (

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -8,9 +8,9 @@ const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element =>
   const addDescriptor = (data: number, key: string) => {
     let descriptor: string = '';
     if (key === 'distance_from_sun' || key === 'diameter') {
-      descriptor = 'kilometers';
+      descriptor = 'km';
     } else if (key === 'mass') {
-      descriptor = 'kilograms';
+      descriptor = 'kg';
     } else if (key === 'length_of_day') {
       descriptor = 'hours';
     } else if (key === 'length_of_year') {
@@ -18,7 +18,7 @@ const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element =>
     } else if (key === 'number_of_moons') {
       descriptor = 'moons'
     } else if (key === 'gravity') {
-      descriptor = 'meters per second squared'
+      descriptor = 'm/s²'
     }
     return (`${data} ${descriptor}`)
   }

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -24,7 +24,10 @@ const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element =>
   }
 
   const planetCards = allPlanets.map(planet => {
-    const factData: string | number = planet[sortKey as keyof PlanetBio]
+    let factData: string | number = planet[sortKey as keyof PlanetBio];
+    if (!factData) {
+      factData = '';
+    }
     return (
       <Planet
         name={planet.name}

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -10,7 +10,7 @@ const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element =>
     if (key === 'distance_from_sun' || key === 'diameter') {
       descriptor = 'km';
     } else if (key === 'mass') {
-      descriptor = 'kg';
+      descriptor = 'quintillion kg';
     } else if (key === 'length_of_day') {
       descriptor = 'hours';
     } else if (key === 'length_of_year') {

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -18,7 +18,7 @@ const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element =>
     } else if (key === 'number_of_moons') {
       descriptor = 'moons'
     } else if (key === 'gravity') {
-      descriptor = 'metres per second squared'
+      descriptor = 'meters per second squared'
     }
     return (`${data} ${descriptor}`)
   }

--- a/src/components/Planetarium/planetarium.css
+++ b/src/components/Planetarium/planetarium.css
@@ -2,6 +2,6 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-evenly;
-  margin: 10px 0;
+  margin: 50px 10px 20px 10px;
   background-color: black;
 }

--- a/src/components/SortBox/SortBox.tsx
+++ b/src/components/SortBox/SortBox.tsx
@@ -10,7 +10,7 @@ const SortBox: React.FC<Props> = ({ updateSort }) => {
     <section className='sort-box'>
       <h2>Sort planets by:</h2>
       <div className='sort-options'>
-        <input type="radio" onClick={updateSort} id="distance" name="sortCriteria" value="distance_from_sun" defaultChecked></input>
+        <input type="radio" onClick={updateSort} id="distance" name="sortCriteria" value="distance_from_sun"></input>
         <label htmlFor="distance"><img className='sort-icon' alt='astronaut icon' src='../space/sun.png'></img>Distance from sun</label>
         <input type="radio" onClick={updateSort} id="mass" name="sortCriteria" value="mass"></input>
         <label htmlFor="mass"><img className='sort-icon' alt='astronaut icon' src='../space/asteroid.png'></img>Mass</label>


### PR DESCRIPTION
# PR PlanetParty
**Connor A-L, Alex T & Katie B**

### What does this do?

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [x] Style
- [ ] Testing

### Are there any known bugs?

- [ ] No
- [x] Yes (if so please disclose in Notes for Reviewer & Next Iterations)

### Summary of the changes
- Fixes style flaws on home page that appeared after switch to Router
- Adjusts styling on home page and planet detail page
- Formats number data in a way that makes sense for each sort category.


### What ticket(s) do the changes resolve?
#41 

Please Link Issues to this PR as necessary.
https://github.com/ConnorAndersonLarson/PlanetParty/issues/41 

### Notes for the Reviewer
I noticed that if we sort by number of moons and the number of moons is 0, then the 0 isn't coming through on the display; it just says the word "moons". I'm not sure if this has been happening for a while or is a new bug. I spent about 15 minutes trying to fix it but didn't track down the problem. Let's discuss in the morning. Maybe with fresh eyes we'll spot a quick fix. If not, we can make an issue for it and fix it later.


### How to Test Changes?
- View the home page after a refresh: spot any problems with the styling?
- Try clicking on each of the sort categories and confirm that the data is being displayed how we'd like it to be. There is some nuance here because not all categories are handled the same way. For example, gravity always shows exactly two decimal places, but length of year shows _up to_ two decimal places. I'm not tied to any of my choices here.
- Click on a planet to go to the detail view and check the new styling tweaks.
- View app with different screen sizes to check responsiveness.


### Next Iterations
