### PR TITLE
Feature/error handling

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,45 +1,5 @@
-import planetData from "./data/planetData"
-
 export const discoverPlanets = () => {
-  // return fetch('https://dry-plains-91502.herokuapp.com/planets')
-  //   .then(response => response.json())
-  //   .then(response => response.map(info => {
-  //     return {
-  //       id: info.id,
-  //       name: info.name,
-  //       mass: info.mass,
-  //       diameter: info.diameter,
-  //       gravity: info.gravity,
-  //       length_of_day: info.length_of_day,
-  //       distance_from_sun: info.distance_from_sun,
-  //       mean_temperature: info.mean_temperature,
-  //       number_of_moons: info.number_of_moons
-  //     }
-  //   }))
-  //   .then(response => response.filter(planet => (planet.name !== 'Moon' && planet.name !== 'Pluto')))
   return fetch('https://api.le-systeme-solaire.net/rest.php/bodies?data=%20id%2C%20englishName%2C%20moons%2C%20mass%2C%20gravity%2C%20massValue%2C%20massExponent%2C%20moon%2C%20meanRadius%2C%20sideralOrbit%2C%20sideralRotation%2C%20semimajorAxis&filter%5B%5D=isPlanet%2Cneq%2Ctrue&filter%5B%5D=')
-    .then(response => response.json())
-
-    .then(response => response.bodies.filter(planet => (planet.id !== 'ceres' && planet.id !== 'pluton' && planet.id !== 'haumea' && planet.id !== 'makemake' && planet.id !== 'eris')))
-    // .then(planets => console.log(planets))
-    .then(planets => planets.map(info => {
-      return {
-        id: info.id,
-        name: info.englishName,
-        mass: parseMass(info.mass.massValue, info.mass.massExponent),
-        diameter: Math.round(info.meanRadius * 2),
-        gravity: info.gravity.toFixed(2),
-        length_of_day: Math.abs(info.sideralRotation).toFixed(1),
-        distance_from_sun: info.semimajorAxis,
-        length_of_year: (info.sideralOrbit.toFixed(2) * 100)/100,
-        number_of_moons: info.moons?.length || 0
-      }
-    }))
-}
-
-const parseMass = (value, exponent) => {
-  const delta = exponent - 18; //to find exponent beyone 10^18 (quintillion)
-  return (value * Math.pow(10, delta));
 }
 
 // id, englishName, moons, mass, gravity, massValue, massExponent, moon, meanRadius, sideralOrbit, sideralRotation, semimajorAxis

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -11,7 +11,7 @@ import SortBox from '../SortBox/SortBox';
 
 
 const parseMass = (value: number, exponent: number) => {
-  const delta = exponent - 18; //to find exponent beyone 10^18 (quintillion)
+  const delta = exponent - 18; //to find exponent beyond 10^18 (quintillion)
   return (value * Math.pow(10, delta));
 }
 class App extends React.Component<{}, AllData> {
@@ -36,22 +36,28 @@ class App extends React.Component<{}, AllData> {
 
   componentDidMount = () => {
     discoverPlanets()
-    .then(response => response.json())
-    .then(response => response.bodies.filter((planet: IncomingData) => (planet.id !== 'ceres' && planet.id !== 'pluton' && planet.id !== 'haumea' && planet.id !== 'makemake' && planet.id !== 'eris')))
-    .then(planets => planets.map((info: IncomingData) => {
-      return {
-        id: info.id,
-        name: info.englishName,
-        mass: parseMass(info.mass.massValue, info.mass.massExponent),
-        diameter: Math.round(info.meanRadius * 2),
-        gravity: info.gravity.toFixed(2),
-        length_of_day: Math.abs(info.sideralRotation).toFixed(1),
-        distance_from_sun: info.semimajorAxis,
-        length_of_year: Math.round(info.sideralOrbit),
-        number_of_moons: info.moons?.length || 0
-      }
-    }))
+      .then(response => {
+        if (!response.ok) {
+          throw new Error();
+        }
+        return response.json();
+      })
+      .then(response => response.bodies.filter((planet: IncomingData) => (planet.id !== 'ceres' && planet.id !== 'pluton' && planet.id !== 'haumea' && planet.id !== 'makemake' && planet.id !== 'eris')))
+      .then(planets => planets.map((info: IncomingData) => {
+        return {
+          id: info.id,
+          name: info.englishName,
+          mass: parseMass(info.mass.massValue, info.mass.massExponent),
+          diameter: Math.round(info.meanRadius * 2),
+          gravity: info.gravity.toFixed(2),
+          length_of_day: Math.abs(info.sideralRotation).toFixed(1),
+          distance_from_sun: info.semimajorAxis,
+          length_of_year: Math.round(info.sideralOrbit),
+          number_of_moons: info.moons?.length || 0
+        }
+      }))
       .then(result => this.setState({ allPlanets: result }))
+      .catch(err => this.setState({ error: 'Oh no! Something went wrong with the data launch!' }))
   }
 
   render() {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { PlanetBio, AllData } from '../../interface';
+import { PlanetBio, AllData, IncomingData } from '../../interface';
 import { discoverPlanets } from '../../apiCalls.js';
 // import planetData from '../../data/planetData.js';
 import Planetarium from '../Planetarium/Planetarium';
@@ -9,12 +9,18 @@ import Header from '../Header/Header';
 import './App.css';
 import SortBox from '../SortBox/SortBox';
 
+
+const parseMass = (value: number, exponent: number) => {
+  const delta = exponent - 18; //to find exponent beyone 10^18 (quintillion)
+  return (value * Math.pow(10, delta));
+}
 class App extends React.Component<{}, AllData> {
   constructor(props: any) {
     super(props);
     this.state = {
       allPlanets: [],
-      sortKey: ''
+      sortKey: '',
+      error: ''
     };
   }
 
@@ -30,6 +36,21 @@ class App extends React.Component<{}, AllData> {
 
   componentDidMount = () => {
     discoverPlanets()
+    .then(response => response.json())
+    .then(response => response.bodies.filter((planet: IncomingData) => (planet.id !== 'ceres' && planet.id !== 'pluton' && planet.id !== 'haumea' && planet.id !== 'makemake' && planet.id !== 'eris')))
+    .then(planets => planets.map((info: IncomingData) => {
+      return {
+        id: info.id,
+        name: info.englishName,
+        mass: parseMass(info.mass.massValue, info.mass.massExponent),
+        diameter: Math.round(info.meanRadius * 2),
+        gravity: info.gravity.toFixed(2),
+        length_of_day: Math.abs(info.sideralRotation).toFixed(1),
+        distance_from_sun: info.semimajorAxis,
+        length_of_year: Math.round(info.sideralOrbit),
+        number_of_moons: info.moons?.length || 0
+      }
+    }))
       .then(result => this.setState({ allPlanets: result }))
   }
 
@@ -42,7 +63,7 @@ class App extends React.Component<{}, AllData> {
             <main>
               <SortBox updateSort={this.updateSort} />
               {!this.state.allPlanets.length && <h2>Loading...</h2>}
-              <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
+              <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} error={this.state.error} />
             </main>
           )
         }} />
@@ -56,7 +77,7 @@ class App extends React.Component<{}, AllData> {
             return (
               <main>
                 <SortBox updateSort={this.updateSort} />
-                <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
+                <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} error={this.state.error}/>
               </main>
             )
           }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -68,7 +68,8 @@ class App extends React.Component<{}, AllData> {
           return (
             <main>
               <SortBox updateSort={this.updateSort} />
-              {!this.state.allPlanets.length && <h2>Loading...</h2>}
+              {this.state.error && <h2>{this.state.error}</h2>}
+              {!this.state.error && !this.state.allPlanets.length && <h2>Loading...</h2>}
               <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} error={this.state.error} />
             </main>
           )
@@ -83,6 +84,8 @@ class App extends React.Component<{}, AllData> {
             return (
               <main>
                 <SortBox updateSort={this.updateSort} />
+                {this.state.error && <h2>{this.state.error}</h2>}
+                {!this.state.error && !this.state.allPlanets.length && <h2>Loading...</h2>}
                 <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} error={this.state.error}/>
               </main>
             )

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -12,5 +12,30 @@ export interface PlanetBio {
 
 export interface AllData {
   allPlanets: Array<PlanetBio>,
-  sortKey: string;
+  sortKey: string,
+  error: string
+}
+
+
+interface Moons {
+  moon: string
+}
+
+// interface Masses {
+//   massValue: number,
+//   massExponent: number
+// }
+export interface IncomingData {
+  id: string,
+  englishName: string,
+  moons: Moons[],
+  semimajorAxis: number,
+  mass: {
+    massValue: number,
+    massExponent: number
+  },
+  gravity: number,
+  meanRadius: number,
+  sideralOrbit: number,
+  sideralRotation: number
 }


### PR DESCRIPTION
# PR PlanetParty
**Connor A-L, Alex T & Katie B**

### What does this do?

- [ ] Fix
- [x] Feature
- [x] Refactor
- [ ] Style
- [ ] Testing

### Are there any known bugs?

- [x] No
- [ ] Yes (if so please disclose in Notes for Reviewer & Next Iterations)

### Summary of the changes
- Moves data handling out of `apiCalls` and into `App`
- (... so that we can use `this.setState` to set an `error` with the correct binding for `this`)
- Adds a `.catch` line to set the `error` property when an error occurs
- Throws a new error when a response is not ok (to catch 400 errors that wouldn't otherwise be caught)
- Renders the error message on the page if the `error` property in state is not an empty string

### What ticket(s) do the changes resolve?
#26
Please Link Issues to this PR as necessary.
https://github.com/ConnorAndersonLarson/PlanetParty/projects/1#card-58893297

### Notes for the Reviewer
There's some refactoring that could be done here, specifically creating a `Main` component to eliminate the duplicate chunks of code to render the landing page, and pulling the data cleaning out into a separate `cleaners` or `helpers` file. 


### How to Test Changes?
The best way to test this will be with Cypress so we can force a network error and make sure we get the desired behavior.


### Next Iterations
