### PR TITLE
Refactor/router add switch

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import { PlanetBio, AllData } from '../../interface';
 import { discoverPlanets } from '../../apiCalls.js';
 // import planetData from '../../data/planetData.js';
@@ -37,36 +37,48 @@ class App extends React.Component<{}, AllData> {
     return (
       <div className="App">
         <Header />
-        <Route exact path="/" render={() => {
-          return (
-            <main>
-              <SortBox updateSort={this.updateSort} />
-              {!this.state.allPlanets.length && <h2>Loading...</h2>}
-              <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
-            </main>
-          )
-        }} />
+        <Switch >
+          <Route exact path="/" render={() => {
+            return (
+              <main>
+                <SortBox updateSort={this.updateSort} />
+                {!this.state.allPlanets.length && <h2>Loading...</h2>}
+                <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
+              </main>
+            )
+          }} />
 
-        <Route path="/:name" render={({ match }) => {
-          const foundPlanet = this.state.allPlanets.find(planet => {
-            return planet.name.toLowerCase() === match.params.name.toLowerCase()
-          });
+          <Route exact path="/:name" render={({ match }) => {
+            const foundPlanet = this.state.allPlanets.find(planet => {
+              return planet.name.toLowerCase() === match.params.name.toLowerCase()
+            })!;
 
-          if (!foundPlanet) {
+            // if (!foundPlanet) {
+            //   return (
+            //     <main>
+            //       <SortBox updateSort={this.updateSort} />
+            //       <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
+            //     </main>
+            //   )
+            // }
+
+            return (
+              <main>
+                <PlanetInfo currentPlanet={foundPlanet} />
+              </main>
+            )
+          }} />
+          <Route path='*' render={() => {
             return (
               <main>
                 <SortBox updateSort={this.updateSort} />
                 <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
               </main>
             )
-          }
+          }}
 
-          return (
-            <main>
-              <PlanetInfo currentPlanet={foundPlanet} />
-            </main>
-          )
-        }} />
+          />
+        </Switch>
         <footer>
           <p className="credits">Icons made by <a href="https://www.flaticon.com/authors/monkik" title="monkik">monkik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></p>
           <p className="credits">Gif made by <a href="https://www.catchmaj.com/">Cat Chmaj</a> at <a href="https://giphy.com/gifs/VI2UC13hwWin1MIfmi">GIPHY</a></p>

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -37,38 +37,40 @@ class App extends React.Component<{}, AllData> {
     return (
       <div className="App">
         <Header />
-        <Switch >
-          <Route exact path="/" render={() => {
-            return (
-              <main>
-                <SortBox updateSort={this.updateSort} />
-                {!this.state.allPlanets.length && <h2>Loading...</h2>}
-                <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
-              </main>
-            )
-          }} />
+        <main>
+          <Switch >
+            <Route exact path="/" render={() => {
+              return (
+                <>
+                  <SortBox updateSort={this.updateSort} />
+                  {!this.state.allPlanets.length && <h2>Loading...</h2>}
+                  <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
+                </>
+              )
+            }} />
 
-          <Route exact path="/:name" render={({ match }) => {
-            const foundPlanet = this.state.allPlanets.find(planet => {
-              return planet.name.toLowerCase() === match.params.name.toLowerCase()
-            })!;
-            return (
-              <main>
-                <PlanetInfo currentPlanet={foundPlanet} />
-              </main>
-            )
-          }} />
-          <Route path='*' render={() => {
-            return (
-              <main>
-                <SortBox updateSort={this.updateSort} />
-                <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
-              </main>
-            )
-          }}
-
-          />
-        </Switch>
+            <Route exact path="/:name" render={({ match }) => {
+              //this ! is weird
+              const foundPlanet = this.state.allPlanets.find(planet => planet.name.toLowerCase() === match.params.name.toLowerCase())!;
+              console.log(foundPlanet);
+              return (
+                <>
+                  {!foundPlanet && <h2>Opps, looks like that planet is out of our solar system</h2>}
+                  {foundPlanet && <PlanetInfo currentPlanet={foundPlanet} />}
+                </>
+              )
+            }} />
+            <Route path='*' render={() => {
+              return (
+                <>
+                  <SortBox updateSort={this.updateSort} />
+                  <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
+                </>
+              )
+            }}
+            />
+          </Switch>
+        </main>
         <footer>
           <p className="credits">Icons made by <a href="https://www.flaticon.com/authors/monkik" title="monkik">monkik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></p>
           <p className="credits">Gif made by <a href="https://www.catchmaj.com/">Cat Chmaj</a> at <a href="https://giphy.com/gifs/VI2UC13hwWin1MIfmi">GIPHY</a></p>

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -52,16 +52,6 @@ class App extends React.Component<{}, AllData> {
             const foundPlanet = this.state.allPlanets.find(planet => {
               return planet.name.toLowerCase() === match.params.name.toLowerCase()
             })!;
-
-            // if (!foundPlanet) {
-            //   return (
-            //     <main>
-            //       <SortBox updateSort={this.updateSort} />
-            //       <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
-            //     </main>
-            //   )
-            // }
-
             return (
               <main>
                 <PlanetInfo currentPlanet={foundPlanet} />

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -31,6 +31,7 @@ class App extends React.Component<{}, AllData> {
   componentDidMount = () => {
     discoverPlanets()
       .then(result => this.setState({ allPlanets: result }))
+      .then(() => console.log('fetched'))
   }
 
   render() {
@@ -48,27 +49,16 @@ class App extends React.Component<{}, AllData> {
                 </>
               )
             }} />
-
             <Route exact path="/:name" render={({ match }) => {
-              //this ! is weird
-              const foundPlanet = this.state.allPlanets.find(planet => planet.name.toLowerCase() === match.params.name.toLowerCase())!;
-              console.log(foundPlanet);
+              const foundPlanet = this.state.allPlanets.find(planet => planet.name.toLowerCase() === match.params.name.toLowerCase());
               return (
                 <>
-                  {!foundPlanet && <h2>Opps, looks like that planet is out of our solar system</h2>}
+                  {!foundPlanet && <h2>Oops, looks like that planet is out of our solar system</h2>}
                   {foundPlanet && <PlanetInfo currentPlanet={foundPlanet} />}
                 </>
               )
             }} />
-            <Route path='*' render={() => {
-              return (
-                <>
-                  <SortBox updateSort={this.updateSort} />
-                  <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} />
-                </>
-              )
-            }}
-            />
+            <Route path='*' render={() => <h2>Oops, looks like that planet is out of our solar system</h2>} />
           </Switch>
         </main>
         <footer>

--- a/src/components/PlanetInfo/PlanetInfo.tsx
+++ b/src/components/PlanetInfo/PlanetInfo.tsx
@@ -9,7 +9,7 @@ interface InfoProps {
 
 const PlanetInfo: React.FC<InfoProps> = ({ currentPlanet }): JSX.Element => {
 
-  const {name, mass, diameter, gravity, length_of_day, distance_from_sun, length_of_year, number_of_moons } = currentPlanet;
+  const { name, mass, diameter, gravity, length_of_day, distance_from_sun, length_of_year, number_of_moons } = currentPlanet;
 
   return (
     <section className='planet-info-view'>


### PR DESCRIPTION
# PR PlanetParty
**Connor A-L, Alex T & Katie B**

### What does this do?

- [X] Fix
- [ ] Feature
- [X] Refactor
- [ ] Style
- [ ] Testing

### Are there any known bugs?

- [ ] No
- [X] Yes (if so please disclose in Notes for Reviewer & Next Iterations)
When a valid URL is entered for a single planet ex. /mars, the error message renders first before the single planet view. This is most likely because a fetch request is called when entering a URL /mars. This might be fixed with an added conditional render statement checking for state.error.

### Summary of the changes
1. Refactor `Router` using `Switch` components. Create a error message for when URL path doesn't match home or single planet view.
2. Move `<main>` tags to surround router, so each `Route` isn't wrapped in a `main` tag.


### What ticket(s) do the changes resolve?

#37 Router Refactor
Please Link Issues to this PR as necessary.

### Notes for the Reviewer
See Bug issue above ^


### How to Test Changes?
Pull down the branch, the site should work as before if paths names don't match home or single planet view an error should display


### Next Iterations

Add additional condition to render of single planet view to check for state error 
