### PR TITLE
Fix/sort buttons add commas

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -30,6 +30,7 @@ class App extends React.Component<{}, AllData> {
     };
   }
 
+
   updateSort = (event: React.MouseEvent<HTMLInputElement>): void => {
     const sortedPlanets = [...this.state.allPlanets];
     const input = event.target as HTMLInputElement;
@@ -39,6 +40,10 @@ class App extends React.Component<{}, AllData> {
 
     this.setState({ allPlanets: [...sortedPlanets], sortKey: sortKey });
   };
+
+  resetSort = (): void => {
+    this.setState({ sortKey: '' })
+  }
 
   componentDidMount = () => {
     discoverPlanets()
@@ -87,7 +92,7 @@ class App extends React.Component<{}, AllData> {
               return (
                 <>
                   {!foundPlanet && <h2>Oops, looks like that planet is out of our solar system</h2>}
-                  {foundPlanet && <PlanetInfo currentPlanet={foundPlanet} />}
+                  {foundPlanet && <PlanetInfo currentPlanet={foundPlanet} resetSort={this.resetSort} />}
                 </>
               )
             }} />

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -13,6 +13,13 @@ const parseMass = (value: number, exponent: number) => {
   const delta = exponent - 18; //to find exponent beyond 10^18 (quintillion)
   return (value * Math.pow(10, delta));
 }
+
+const formateLargeNumbers = (number: number): string => {
+  let totalFormatted = number.toString().split('.');
+  totalFormatted[0] = totalFormatted[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return (totalFormatted.join('.'));
+}
+
 class App extends React.Component<{}, AllData> {
   constructor(props: any) {
     super(props);
@@ -46,11 +53,11 @@ class App extends React.Component<{}, AllData> {
         return {
           id: info.id,
           name: info.englishName,
-          mass: parseMass(info.mass.massValue, info.mass.massExponent),
-          diameter: Math.round(info.meanRadius * 2),
+          mass: formateLargeNumbers(parseMass(info.mass.massValue, info.mass.massExponent)),
+          diameter: formateLargeNumbers(Math.round(info.meanRadius * 2)),
           gravity: info.gravity.toFixed(2),
           length_of_day: Math.abs(info.sideralRotation).toFixed(1),
-          distance_from_sun: info.semimajorAxis,
+          distance_from_sun: formateLargeNumbers(info.semimajorAxis),
           length_of_year: Math.round(info.sideralOrbit),
           number_of_moons: info.moons?.length || 0
         }
@@ -69,9 +76,9 @@ class App extends React.Component<{}, AllData> {
               return (
                 <>
                   <SortBox updateSort={this.updateSort} />
-                    {this.state.error && <h2>{this.state.error}</h2>}
-                    {!this.state.error && !this.state.allPlanets.length && <h2>Loading...</h2>}
-                  <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} error={this.state.error}/>
+                  {this.state.error && <h2>{this.state.error}</h2>}
+                  {!this.state.error && !this.state.allPlanets.length && <h2>Loading...</h2>}
+                  <Planetarium allPlanets={this.state.allPlanets} sortKey={this.state.sortKey} error={this.state.error} />
                 </>
               )
             }} />

--- a/src/components/Planet/Planet.tsx
+++ b/src/components/Planet/Planet.tsx
@@ -4,7 +4,6 @@ import { PlanetProps } from '../../interface';
 import './planet.css';
 
 const Planet: React.FC<PlanetProps> = ({ id, name, planetFact }): JSX.Element => {
-
   return (
     <Link to={`/${name.toLowerCase()}`} className='planet-card' id={id.toString()}>
       <img className='planet-icon' alt={name} src={`../planets/${name}.png`} />

--- a/src/components/PlanetInfo/PlanetInfo.tsx
+++ b/src/components/PlanetInfo/PlanetInfo.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import './planetInfo.css';
 import { InfoProps } from '../../interface';
 
-const PlanetInfo: React.FC<InfoProps> = ({ currentPlanet }): JSX.Element => {
+const PlanetInfo: React.FC<InfoProps> = ({ currentPlanet, resetSort }): JSX.Element => {
   const [input, setInput] = useState('100');
 
   const { name, mass, diameter, gravity, length_of_day, distance_from_sun, length_of_year, number_of_moons } = currentPlanet;
@@ -15,7 +15,7 @@ const PlanetInfo: React.FC<InfoProps> = ({ currentPlanet }): JSX.Element => {
 
   return (
     <section className='planet-info-view'>
-      <Link to="/" className='back'>⬅ Back to all planets</Link>
+      <Link to="/" onClick={() => resetSort()} className='back'>⬅ Back to all planets</Link>
       <h2 className='planet-info-title' >{name}</h2>
       <img className='planet-info-img' src={`../planet-pics/${name}-pic.jpg`} alt={name}></img>
       <article className='planet-info-box'>

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -5,22 +5,36 @@ import Planet from '../Planet/Planet';
 
 const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element => {
 
-  const addDescriptor = (data: number, key: string) => {
+  const formateLargeNumbers = (number: number): string => {
+    let totalFormatted = number.toString().split('.');
+    totalFormatted[0] = totalFormatted[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    console.log(totalFormatted[0])
+    return (totalFormatted.join('.'));
+  }
+
+  const addDescriptor = (data: number, key: string): string => {
     let descriptor: string = '';
+    let formattedData: string = ''
     if (key === 'distance_from_sun' || key === 'diameter') {
       descriptor = 'km';
+      formattedData = formateLargeNumbers(data);
     } else if (key === 'mass') {
       descriptor = 'quintillion kg';
+      formattedData = formateLargeNumbers(data);
     } else if (key === 'length_of_day') {
       descriptor = 'hours';
+      formattedData = `${data}`;
     } else if (key === 'length_of_year') {
       descriptor = 'days'
+      formattedData = `${data}`;
     } else if (key === 'number_of_moons') {
       descriptor = 'moons'
+      formattedData = `${data}`;
     } else if (key === 'gravity') {
       descriptor = 'm/s²'
+      formattedData = `${data}`;
     }
-    return (`${data} ${descriptor}`)
+    return (`${formattedData} ${descriptor}`)
   }
 
   const planetCards = allPlanets.map(planet => {

--- a/src/components/Planetarium/Planetarium.tsx
+++ b/src/components/Planetarium/Planetarium.tsx
@@ -5,36 +5,22 @@ import Planet from '../Planet/Planet';
 
 const Planetarium: React.FC<AllData> = ({ allPlanets, sortKey }): JSX.Element => {
 
-  const formateLargeNumbers = (number: number): string => {
-    let totalFormatted = number.toString().split('.');
-    totalFormatted[0] = totalFormatted[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    console.log(totalFormatted[0])
-    return (totalFormatted.join('.'));
-  }
-
   const addDescriptor = (data: number, key: string): string => {
     let descriptor: string = '';
-    let formattedData: string = ''
     if (key === 'distance_from_sun' || key === 'diameter') {
       descriptor = 'km';
-      formattedData = formateLargeNumbers(data);
     } else if (key === 'mass') {
       descriptor = 'quintillion kg';
-      formattedData = formateLargeNumbers(data);
     } else if (key === 'length_of_day') {
       descriptor = 'hours';
-      formattedData = `${data}`;
     } else if (key === 'length_of_year') {
       descriptor = 'days'
-      formattedData = `${data}`;
     } else if (key === 'number_of_moons') {
       descriptor = 'moons'
-      formattedData = `${data}`;
     } else if (key === 'gravity') {
       descriptor = 'm/s²'
-      formattedData = `${data}`;
     }
-    return (`${formattedData} ${descriptor}`)
+    return (`${data} ${descriptor}`)
   }
 
   const planetCards = allPlanets.map(planet => {

--- a/src/components/SortBox/SortBox.tsx
+++ b/src/components/SortBox/SortBox.tsx
@@ -3,6 +3,7 @@ import { Props } from '../../interface';
 import './SortBox.css';
 
 const SortBox: React.FC<Props> = ({ updateSort }) => {
+
   return (
     <section className='sort-box'>
       <h2>Sort planets by:</h2>

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -24,6 +24,7 @@ export interface PlanetProps {
 
 export interface InfoProps {
   currentPlanet: PlanetBio;
+  resetSort: () => void
 }
 
 export interface Props {


### PR DESCRIPTION
# PR PlanetParty
**Connor A-L, Alex T & Katie B**

### What does this do?

- [X] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Style
- [ ] Testing

### Are there any known bugs?

- [X] No
- [ ] Yes (if so please disclose in Notes for Reviewer & Next Iterations)

### Summary of the changes
Reset sort state in `App` when returning home.
Add function to convert large numbers to include commas.


### What ticket(s) do the changes resolve?
Card about sort bug and card about adding commas to data.

Please Link Issues to this PR as necessary.

### Notes for the Reviewer
Can add the formateLargeNumbers function to any of the data we want!


### How to Test Changes?

Commas should display in Mass, Diameter, and Distance from the sun. When viewing planets details should return home and no planet fact should be displayed.

### Next Iterations
