### PR TITLE
Refactor styling to adjust for contrast errors and header height

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -10,6 +10,7 @@
 .giphy-embed {
   width: 270px;
   border: 0;
+  display: block;
 }
 
 .title {

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -32,6 +32,7 @@
 
   .giphy-embed {
     width: 210px;
+    height: auto;
   }
 }
 
@@ -42,5 +43,6 @@
 
   .giphy-embed {
     width: 150px;
+    height: auto;
   }
 }

--- a/src/components/PlanetInfo/planetInfo.css
+++ b/src/components/PlanetInfo/planetInfo.css
@@ -313,13 +313,18 @@ Light Gray: #D0D7DF */
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
-    width: 60%;
+    width: 70%;
   }
 }
 
 @media only screen and (max-width: 850px) {
   .planet-info-img {
     width: 300px;
+  }
+
+  .planet-info-column {
+    width: 90%;
+    min-width: unset;
   }
 }
 

--- a/src/components/SortBox/SortBox.css
+++ b/src/components/SortBox/SortBox.css
@@ -7,6 +7,7 @@
 
 .sort-icon {
   width: 50px;
+  background-color: transparent;
 }
 
 .sort-options {


### PR DESCRIPTION
# PR PlanetParty
**Connor A-L, Alex T & Katie B**

### What does this do?

- [X] Fix
- [ ] Feature
- [ ] Refactor
- [X] Style
- [ ] Testing

### Are there any known bugs?

- [ ] No
- [X] Yes (if so please disclose in Notes for Reviewer & Next Iterations)

### Summary of the changes
Add display block to the giphy styling, seems like since the giph is wrapped in a link it comes with some weird inherent styling


### What ticket(s) do the changes resolve?
None, just small bug fixes.
Please Link Issues to this PR as necessary.

### Notes for the Reviewer
Still some weird stuff going on in mobile views, content is overflowing past screen width.


### How to Test Changes?
View the deployed site.


### Next Iterations
Look into responsive styling for mobile view. Maybe try using widths?
